### PR TITLE
Feat: API 주소 권한 설정 및 리뷰/답글 삭제 후 재작성 등 코드 수정

### DIFF
--- a/src/main/java/com/sparta/tentenbackend/domain/category/entity/Category.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/category/entity/Category.java
@@ -25,7 +25,7 @@ public class Category extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, unique = true)
   private String name;
 
   public Category(CategoryRequestDto requestDto) {

--- a/src/main/java/com/sparta/tentenbackend/domain/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/category/service/CategoryServiceImpl.java
@@ -24,7 +24,7 @@ public class CategoryServiceImpl implements CategoryService {
   @Transactional
   public CategoryResponseDto addCategory(CategoryRequestDto requestDto, User user) {
     Category category = categoryRepository.save(new Category(requestDto));
-      return new CategoryResponseDto(category);
+    return new CategoryResponseDto(category);
   }
 
   // 카테고리 목록 조회

--- a/src/main/java/com/sparta/tentenbackend/domain/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/category/service/CategoryServiceImpl.java
@@ -19,18 +19,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class CategoryServiceImpl implements CategoryService {
   private final CategoryRepository categoryRepository;
 
-  // TODO /api/master/category 는 userRoleEnum.MASTER만 가능하도록 권한 설정
-
   // 카테고리 추가
   @Override
   @Transactional
   public CategoryResponseDto addCategory(CategoryRequestDto requestDto, User user) {
-    if (user.getRole() == UserRoleEnum.MASTER) {
-      Category category = categoryRepository.save(new Category(requestDto));
+    Category category = categoryRepository.save(new Category(requestDto));
       return new CategoryResponseDto(category);
-    } else {
-      throw new ForbiddenException("카테고리를 생성할 권한이 없습니다.");
-    }
   }
 
   // 카테고리 목록 조회
@@ -50,13 +44,9 @@ public class CategoryServiceImpl implements CategoryService {
   public CategoryResponseDto modifyCategory(CategoryRequestDto requestDto, User user) {
     Category category = categoryRepository.findById(requestDto.getId()).orElseThrow(() ->
         new NullPointerException("해당 카테고리는 존재하지 않습니다."));
-    if (user.getRole() == UserRoleEnum.MASTER) {
-      category.updateById(requestDto);
-      categoryRepository.save(category);
-      return new CategoryResponseDto(category);
-    } else {
-      throw new ForbiddenException("카테고리를 생성할 권한이 없습니다.");
-    }
+    category.updateById(requestDto);
+    categoryRepository.save(category);
+    return new CategoryResponseDto(category);
   }
 
   // 카테고리 삭제
@@ -65,11 +55,7 @@ public class CategoryServiceImpl implements CategoryService {
   public void removeCategory(String categoryId, User user) {
     Category category = categoryRepository.findById(UUID.fromString(categoryId)).orElseThrow(() ->
         new NullPointerException("해당 카테고리는 존재하지 않습니다."));
-    if (user.getRole() == UserRoleEnum.MASTER) {
-      category.markAsDeleted(); // 카테고리의 isDeleted true
-      categoryRepository.save(category);
-    } else {
-      throw new ForbiddenException("카테고리를 생성할 권한이 없습니다.");
-    }
+    category.markAsDeleted(); // 카테고리의 isDeleted true
+    categoryRepository.save(category);
   }
 }

--- a/src/main/java/com/sparta/tentenbackend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/controller/ReviewController.java
@@ -58,7 +58,7 @@ public class ReviewController {
     return ResponseEntity.ok(reviews);
   }
 
-  // 리뷰 검색
+  // 내가 쓴 리뷰 검색
   @GetMapping("/search")
   public ResponseEntity<Page<ReviewResponseDto>> searchReviewsByKeyword(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam("searchType") int searchType, @RequestParam("keyword") String keyword, @RequestParam("page") int page, @RequestParam("size") int size, @RequestParam("sortBy") String sortBy, @RequestParam("isAsc") boolean isAsc) {
     Page<ReviewResponseDto> reviews = reviewService.searchReviewsByKeyword(userDetails.getUser(), searchType, keyword, page - 1, size, sortBy, isAsc);

--- a/src/main/java/com/sparta/tentenbackend/domain/review/entity/OwnerReview.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/entity/OwnerReview.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -30,8 +31,8 @@ public class OwnerReview extends BaseEntity {
   @Column(nullable = false)
   private String content;
 
-  @OneToOne
-  @JoinColumn(name = "review_id", unique = true)
+  @ManyToOne
+  @JoinColumn(name = "review_id")
   private Review review;
 
   public OwnerReview(OwnerReviewRequestDto requestDto, Review review) {

--- a/src/main/java/com/sparta/tentenbackend/domain/review/entity/Review.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/entity/Review.java
@@ -63,4 +63,12 @@ public class Review extends BaseEntity {
     this.setDeleted(true);
     this.setDeletedAt(LocalDateTime.now());
   }
+
+  public void reWriteReview(String content, int grade, String imageUrl) {
+    this.content = content;
+    this.grade = grade;
+    this.image = imageUrl;
+    this.setDeleted(false);
+    this.setDeletedAt(null);
+  }
 }

--- a/src/main/java/com/sparta/tentenbackend/domain/review/entity/Review.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/entity/Review.java
@@ -4,12 +4,14 @@ import com.sparta.tentenbackend.domain.order.entity.Order;
 import com.sparta.tentenbackend.domain.review.dto.CreateReviewRequestDto;
 import com.sparta.tentenbackend.domain.review.dto.UpdateReviewRequestDto;
 import com.sparta.tentenbackend.global.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -42,7 +44,7 @@ public class Review extends BaseEntity {
   @Column
   private String image;
 
-  @OneToOne
+  @ManyToOne
   @JoinColumn(name = "order_id")
   private Order order;
 
@@ -62,13 +64,5 @@ public class Review extends BaseEntity {
   public void markAsDeleted() {
     this.setDeleted(true);
     this.setDeletedAt(LocalDateTime.now());
-  }
-
-  public void reWriteReview(String content, int grade, String imageUrl) {
-    this.content = content;
-    this.grade = grade;
-    this.image = imageUrl;
-    this.setDeleted(false);
-    this.setDeletedAt(null);
   }
 }

--- a/src/main/java/com/sparta/tentenbackend/domain/review/repository/OwnerReviewRepository.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/repository/OwnerReviewRepository.java
@@ -8,5 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface OwnerReviewRepository extends JpaRepository<OwnerReview, UUID> {
 
-  OwnerReview findByReview_Id(UUID id);
+  OwnerReview findByReview_IdAndIsDeletedFalse(UUID reviewId);
+
+  OwnerReview findByIdAndIsDeletedFalse(UUID id);
 }

--- a/src/main/java/com/sparta/tentenbackend/domain/review/repository/OwnerReviewRepository.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/repository/OwnerReviewRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface OwnerReviewRepository extends JpaRepository<OwnerReview, UUID> {
 
+  OwnerReview findByReview_Id(UUID id);
 }

--- a/src/main/java/com/sparta/tentenbackend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/repository/ReviewRepository.java
@@ -13,4 +13,6 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> , ReviewRe
   Page<Review> findAllByOrder_User_IdAndIsDeletedFalse(Long id, Pageable pageable);
 
   Review findByOrder_IdAndIsDeletedFalse(UUID orderId);
+
+  Review findByIdAndIsDeletedFalse(UUID reviewId);
 }

--- a/src/main/java/com/sparta/tentenbackend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/repository/ReviewRepository.java
@@ -12,5 +12,5 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> , ReviewRe
 
   Page<Review> findAllByOrder_User_IdAndIsDeletedFalse(Long id, Pageable pageable);
 
-  Review findByOrder_Id(UUID orderId);
+  Review findByOrder_IdAndIsDeletedFalse(UUID orderId);
 }

--- a/src/main/java/com/sparta/tentenbackend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/repository/ReviewRepository.java
@@ -11,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface ReviewRepository extends JpaRepository<Review, UUID> , ReviewRepositoryCustom {
 
   Page<Review> findAllByOrder_User_IdAndIsDeletedFalse(Long id, Pageable pageable);
+
+  Review findByOrder_Id(UUID orderId);
 }

--- a/src/main/java/com/sparta/tentenbackend/domain/review/service/OwnerReviewServiceImpl.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/service/OwnerReviewServiceImpl.java
@@ -23,8 +23,6 @@ public class OwnerReviewServiceImpl implements OwnerReviewService {
   private final ReviewRepository reviewRepository;
 
   // TODO review.getOrder().getStore().getUser().getId() 리팩토링 필요함. > 결합도 too much
-  // TODO user.getRole() == UserRoleEnum.OWNER인 건 WebSecurityConfig에서 확인하도록 설정 필요함.
-
   // 리뷰에 사장님 답글 달기
   @Override
   public OwnerReviewResponseDto addOwnerReview(OwnerReviewRequestDto requestDto, User user) {

--- a/src/main/java/com/sparta/tentenbackend/domain/review/service/OwnerReviewServiceImpl.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/service/OwnerReviewServiceImpl.java
@@ -8,6 +8,7 @@ import com.sparta.tentenbackend.domain.review.repository.OwnerReviewRepository;
 import com.sparta.tentenbackend.domain.review.repository.ReviewRepository;
 import com.sparta.tentenbackend.domain.user.entity.User;
 import com.sparta.tentenbackend.domain.user.entity.UserRoleEnum;
+import com.sparta.tentenbackend.global.exception.BadRequestException;
 import com.sparta.tentenbackend.global.exception.NotFoundException;
 import com.sparta.tentenbackend.global.exception.UnauthorizedException;
 import java.util.UUID;
@@ -27,13 +28,19 @@ public class OwnerReviewServiceImpl implements OwnerReviewService {
   @Override
   public OwnerReviewResponseDto addOwnerReview(OwnerReviewRequestDto requestDto, User user) {
     UUID reviewId = UUID.fromString(requestDto.getReviewId());
-    Review review = reviewRepository.findById(reviewId)
-        .orElseThrow(() -> new NotFoundException("해당 리뷰를 찾을 수 없습니다."));
+    Review review = reviewRepository.findByIdAndIsDeletedFalse(reviewId);
+    if (review == null) {
+      throw new BadRequestException("해당 리뷰가 존재하지 않습니다.");
+    }
     // 유저가 OWNER고, 유저아이디가 가게 사장님 아이디와 일치할 때
     Long ownerUserId = review.getOrder().getStore().getUser().getId();
     if (user.getId().equals(ownerUserId)) {
-    OwnerReview ownerReview = ownerReviewRepository.save(new OwnerReview(requestDto, review));
-    return new OwnerReviewResponseDto(ownerReview);
+      OwnerReview existingOwnerReview = ownerReviewRepository.findByReview_IdAndIsDeletedFalse(reviewId);
+      if (existingOwnerReview != null) {  // 이미 기존에 답글을 작성한 경우
+        throw new BadRequestException("이미 해당 리뷰에 대한 답글을 작성하셨습니다.");
+      }
+      OwnerReview ownerReview = ownerReviewRepository.save(new OwnerReview(requestDto, review));
+      return new OwnerReviewResponseDto(ownerReview);
     } else {
       throw new UnauthorizedException("해당 리뷰에 대한 권한이 없습니다.");
     }
@@ -42,8 +49,10 @@ public class OwnerReviewServiceImpl implements OwnerReviewService {
   // 답글 수정
   @Override
   public OwnerReviewResponseDto modifyOwnerReview(OwnerReviewRequestDto requestDto, User user) {
-    OwnerReview ownerReview = ownerReviewRepository.findById(requestDto.getId())
-        .orElseThrow(() -> new NotFoundException("해당 답글을 찾을 수 없습니다."));
+    OwnerReview ownerReview = ownerReviewRepository.findByIdAndIsDeletedFalse(requestDto.getId());
+    if (ownerReview == null) {
+      throw new NotFoundException("해당 답글을 찾을 수 없습니다.");
+    }
     // 유저아이디가 가게 사장님 아이디와 일치할 때
     Long ownerUserId = ownerReview.getReview().getOrder().getStore().getUser().getId();
     if (user.getId().equals(ownerUserId)) {
@@ -58,8 +67,10 @@ public class OwnerReviewServiceImpl implements OwnerReviewService {
   // 답글 삭제
   @Override
   public void removeOwnerReview(String ownerReviewId, User user) {
-    OwnerReview ownerReview = ownerReviewRepository.findById(UUID.fromString(ownerReviewId))
-        .orElseThrow(() -> new NotFoundException("해당 답글을 찾을 수 없습니다."));
+    OwnerReview ownerReview = ownerReviewRepository.findByIdAndIsDeletedFalse(UUID.fromString(ownerReviewId));
+    if (ownerReview == null) {
+      throw new NotFoundException("해당 답글을 찾을 수 없습니다.");
+    }
     // 유저아이디가 가게 사장님 아이디와 일치할 때
     Long ownerUserId = ownerReview.getReview().getOrder().getStore().getUser().getId();
     if (user.getId().equals(ownerUserId)) {

--- a/src/main/java/com/sparta/tentenbackend/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/service/ReviewServiceImpl.java
@@ -55,17 +55,39 @@ public class ReviewServiceImpl implements ReviewService {
     if (order.getOrderStatus() != OrderStatus.DELIVERY_COMPLETED) {
       throw new BadRequestException("리뷰는 배달완료된 주문에 대해서만 작성할 수 있습니다.");
     }
-    // 파일이 존재하면 S3에 파일 업로드
-    String imageUrl = null;
-    if (requestDto.getFile() != null && !requestDto.getFile().isEmpty()) {
-      imageUrl = s3Service.uploadFile(requestDto.getFile());
+    // 기존 리뷰가 있는 경우, 삭제된 리뷰인지 확인 후 복구
+    Review existingReview = reviewRepository.findByOrder_Id(orderId);
+    if (existingReview != null) { // 리뷰가 이미 존재한다면
+      if (existingReview.isDeleted()) { // 리뷰가 삭제된 상태라면
+        String imageUrl = null;
+        if (existingReview.getImage() != null && !existingReview.getImage().isEmpty()) {  // 저장된 리뷰 사진이 있다면
+          s3Service.deleteFile(existingReview.getImage());  // 삭제
+        } // 없으면 받은 파일 업로드
+        imageUrl = s3Service.uploadFile(requestDto.getFile());
+        // 리뷰 내용 업데이트
+        existingReview.reWriteReview(requestDto.getContent(), requestDto.getGrade(), imageUrl);
+        updateStoreReviewStats(order, requestDto.getGrade());
+        return new ReviewResponseDto(existingReview);
+      }
+      //
+      throw new BadRequestException("리뷰가 이미 존재합니다.");
+    } else {  // 리뷰를 처음 작성하는 경우
+      // 파일이 존재하면 S3에 파일 업로드
+      String imageUrl = null;
+      if (requestDto.getFile() != null && !requestDto.getFile().isEmpty()) {
+        imageUrl = s3Service.uploadFile(requestDto.getFile());
+      }
+      Review review = reviewRepository.save(new Review(requestDto, imageUrl, order));
+      // 리뷰 생성시 가게 총 평점 합계, 총 리뷰 개수 저장
+      updateStoreReviewStats(order, requestDto.getGrade());
+      return new ReviewResponseDto(review);
     }
-    Review review = reviewRepository.save(new Review(requestDto, imageUrl, order));
-    // 리뷰 생성시 가게 총 평점 합계, 총 리뷰 개수 저장
+  }
+
+  private void updateStoreReviewStats(Order order, int grade) {
     Store store = order.getStore();
-    store.updateReviewStats(requestDto.getGrade());
+    store.updateReviewStats(grade);
     storeRepository.save(store);
-    return new ReviewResponseDto(review);
   }
 
   // 모든 사용자가 볼 수 있는 가게별 리뷰 목록 조회
@@ -101,7 +123,7 @@ public class ReviewServiceImpl implements ReviewService {
     }
   }
 
-  // 리뷰 검색
+  // 내가 작성한 리뷰 검색
   @Override
   public Page<ReviewResponseDto> searchReviewsByKeyword(User user, int searchType, String keyword, int page, int size, String sortBy, boolean isAsc) {
     Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
@@ -144,9 +166,10 @@ public class ReviewServiceImpl implements ReviewService {
     int oldGrade = review.getGrade(); // 기존 평점
     // 파일이 존재하면 파일 대체
     String imageUrl = null;
-    if (requestDto.getFile() != null && !requestDto.getFile().isEmpty()) {
-      imageUrl = s3Service.updateFile(review.getImage(), requestDto.getFile());
+    if (review.getImage() != null && !review.getImage().isEmpty()) {
+      s3Service.deleteFile(review.getImage());
     }
+    imageUrl = s3Service.uploadFile(requestDto.getFile());
     // 리뷰 내용 업데이트
     review.updateById(requestDto, imageUrl);
     // 가게 총 평점 합계 업데이트
@@ -167,7 +190,9 @@ public class ReviewServiceImpl implements ReviewService {
       throw new ForbiddenException("해당 리뷰의 작성자가 아닙니다.");
     }
     Store store = review.getOrder().getStore();
-    s3Service.deleteFile(review.getImage());
+    if (review.getImage() != null && !review.getImage().isEmpty()) {
+      s3Service.deleteFile(review.getImage());
+    }
     review.markAsDeleted();
     store.removeReviewStats(review.getGrade());
     reviewRepository.save(review);

--- a/src/main/java/com/sparta/tentenbackend/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/service/ReviewServiceImpl.java
@@ -142,8 +142,10 @@ public class ReviewServiceImpl implements ReviewService {
   @Override
   @Transactional
   public ReviewResponseDto modifyReview(UpdateReviewRequestDto requestDto, User user) throws IOException {
-    Review review = reviewRepository.findById(UUID.fromString(requestDto.getId())).orElseThrow(() ->
-        new NotFoundException("해당 리뷰는 존재하지 않습니다."));
+    Review review = reviewRepository.findByIdAndIsDeletedFalse(UUID.fromString(requestDto.getId()));
+    if (review == null) {
+      throw new NotFoundException("해당 리뷰는 존재하지 않습니다.");
+    }
     // 리뷰 작성자 == 주문자 == 로그인 유저인지 확인하기
     if (review.getOrder().getUser().getId() != user.getId()) {
       throw new ForbiddenException("해당 리뷰의 작성자가 아닙니다.");
@@ -170,8 +172,10 @@ public class ReviewServiceImpl implements ReviewService {
   @Override
   @Transactional
   public void removeReview(String reviewId, User user) {
-    Review review = reviewRepository.findById(UUID.fromString(reviewId)).orElseThrow(() ->
-        new NotFoundException("해당 리뷰는 존재하지 않습니다."));
+    Review review = reviewRepository.findByIdAndIsDeletedFalse(UUID.fromString(reviewId));
+    if (review == null) {
+      throw new NotFoundException("해당 리뷰는 존재하지 않습니다.");
+    }
     // 리뷰 작성자 == 주문자 == 로그인 유저인지 확인하기
     if (review.getOrder().getUser().getId() != user.getId()) {
       throw new ForbiddenException("해당 리뷰의 작성자가 아닙니다.");

--- a/src/main/java/com/sparta/tentenbackend/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/sparta/tentenbackend/domain/review/service/ReviewServiceImpl.java
@@ -92,7 +92,7 @@ public class ReviewServiceImpl implements ReviewService {
   public Page<ReviewResponseDto> findAllReviews(User user, int page, int size, String sortBy, boolean isAsc) {
     Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
     Sort sort = getSortByField(sortBy, direction);
-    Pageable pageable = PageRequest.of(page, size, sort);
+    Pageable pageable = PageRequest.of(page, getValidPageSize(size), sort);
 
     // review 테이블에 저장된 order로 order.getUser().getId() == user.getId() 인 리뷰 목록/isDeleted=false만 조회하기
     Page<Review> reviews = reviewRepository.findAllByOrder_User_IdAndIsDeletedFalse(user.getId(), pageable);

--- a/src/main/java/com/sparta/tentenbackend/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/tentenbackend/global/config/WebSecurityConfig.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -100,8 +101,15 @@ public class WebSecurityConfig {
             .requestMatchers("/api/master/category").hasAuthority(UserRoleEnum.Authority.MASTER)
             .requestMatchers("/api/category").permitAll()
 
-            //  [리뷰 API] 고객(Customer)과 점주(Owner)만 리뷰 작성 가능
-            .requestMatchers("/api/review").hasAuthority(UserRoleEnum.Authority.CUSTOMER)
+            //  [리뷰 API]
+            .requestMatchers(HttpMethod.GET, "/api/review").permitAll() // 가게별 리뷰 목록 모든 사용자 허용, 그 외 모두
+            .requestMatchers(HttpMethod.GET, "/api/review/my-reviews").hasAuthority(UserRoleEnum.Authority.CUSTOMER)
+            .requestMatchers(HttpMethod.GET, "/api/review/search").hasAuthority(UserRoleEnum.Authority.CUSTOMER)
+            .requestMatchers(HttpMethod.POST, "/api/review").hasAuthority(UserRoleEnum.Authority.CUSTOMER)
+            .requestMatchers(HttpMethod.PUT, "/api/review").hasAuthority(UserRoleEnum.Authority.CUSTOMER)
+            .requestMatchers(HttpMethod.DELETE, "/api/review").hasAuthority(UserRoleEnum.Authority.CUSTOMER)
+
+            //  [사장님의 리뷰 API] 사장님(Owner)만 리뷰 답글 작성, 수정, 삭제 가능
             .requestMatchers("/api/owner/review").hasAuthority(UserRoleEnum.Authority.OWNER)
 
             // TODO: [파일 업로드 API] 관리자(Master)만 파일 업로드/삭제 가능인지 확인
@@ -115,9 +123,8 @@ public class WebSecurityConfig {
             .requestMatchers("/api/payment/**")
             .hasAuthority(Authority.CUSTOMER)
 
-            // [AI API]
-            .requestMatchers("/api/ai")
-            .hasAuthority(Authority.CUSTOMER)
+            // [AI API] 가게 사장님이 메뉴 설명 작성할 때 사용
+            .requestMatchers("/api/ai").hasAuthority(Authority.OWNER)
 
             // 기본적으로 모든 요청은 인증이 필요함
             .anyRequest().authenticated()

--- a/src/main/resources/town_code_insert/insert_test_data_queires.sql
+++ b/src/main/resources/town_code_insert/insert_test_data_queires.sql
@@ -24,7 +24,7 @@ INSERT INTO p_store (id, name, address, phone_number, image, user_id, category_i
                      total_review_count)
 VALUES ('550e8400-e29b-41d4-a716-446655440010', '김밥천국', '서울특별시 종로구 청운동 1-1', '010-1111-2222',
         'kimbap.jpg',
-        2, '550e8400-e29b-41d4-a716-446655440000',
+        1, '550e8400-e29b-41d4-a716-446655440000',
         '1111010100', NOW(), NOW(), NULL, FALSE, 0, 0);
 
 INSERT INTO p_store (id, name, address, phone_number, image, user_id, category_id, town_code,
@@ -32,7 +32,7 @@ INSERT INTO p_store (id, name, address, phone_number, image, user_id, category_i
                      total_review_count)
 VALUES ('550e8400-e29b-41d4-a716-446655440001', '이탈리안 피자', '서울특별시 종로구 신교동 2-2', '010-2222-3333',
         'pizza.jpg',
-        2, '550e8400-e29b-41d4-a716-446655440001',
+        1, '550e8400-e29b-41d4-a716-446655440001',
         '1111010200', NOW(), NOW(), NULL, FALSE, 0, 0);
 
 -- 3. 메뉴 (Menu) 데이터 삽입


### PR DESCRIPTION
### 📍 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정
- [ ] 릴리즈

### ❗️ 관련 이슈 링크
Close # 59

### 🔁 변경 및 추가사항
- 데이터도 일종의 자산이므로 soft delete 의도에 맞게 리뷰 삭제시 이미지 파일을 삭제하지 않음. (업뎃시 기존 이미지 파일만 삭제)
- 삭제 후 재작성하는 경우를 위해 isDeletedFalse인 리뷰/답글을 조회 후 null인 경우 새로 생성, 아닌 경우 예외처리할 수 있도록 연관관계 아래와 같이 변경함.
1) Order:Review = 1:N
2) Review:OwnerReview = 1:N
- Category>name unique=true
- 페이징 제한 빠진 메서드 하나에 추가 완료

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
